### PR TITLE
get DKIM & SPF from rspamd/spamassassin too

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,9 @@
 
-# 1.0.0 - 201_-__-__
+# 1.0.1 - 2019-04-02
+
+- get SPF & DKIM results from rspamd & spamassassin
+
+
+# 1.0.0 - 2019-04-01
 
 - initial release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-dmarc-perl",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Haraka plugin that DMARC validates incoming messages",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Now the DMARC module will fetch SPF & DKIM results from the native Haraka plugins as well as limited results from rspamd and SpamAssassin (if enabled). I'm seeing instances where Haraka breaks DKIM validation (similar to #2594) but SpamAssassin still validates.

Checklist:
- [x] docs updated
- [ ] tests updated
- [x] Changes.md updated
- [x] package.json.version bumped
- [x] published to NPM (will be done by @core)